### PR TITLE
Exercise 3.1 with the single threaded executor

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -23,6 +23,18 @@
       "cStandard": "gnu11",
       "cppStandard": "gnu++17",
       "compileCommands": "${workspaceFolder}/exercise2/build/compile_commands.json"
+    },
+    {
+      "includePath": [
+        "/opt/ros/humble/include/**",
+        "/usr/include/**"
+      ],
+      "name": "Exercise 3-1",
+      "intelliSenseMode": "gcc-x64",
+      "compilerPath": "/usr/bin/gcc",
+      "cStandard": "gnu11",
+      "cppStandard": "gnu++17",
+      "compileCommands": "${workspaceFolder}/exercise3-1/build/compile_commands.json"
     }
   ],
   "version": 4

--- a/exercise3-1/src/camera_demo/CMakeLists.txt
+++ b/exercise3-1/src/camera_demo/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.18)
+project(camera_demo_3_1)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# CactusRT
+add_subdirectory(
+  ${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/cactus-rt-integrated
+  ${CMAKE_CURRENT_BINARY_DIR}/cactus-rt-build
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(camera_demo_interfaces REQUIRED)
+
+add_executable(camera_demo
+  src/main.cc
+  src/system_nodes.cc
+  src/camera_processing_nodes.cc
+  src/tracing.cc
+)
+
+target_include_directories(camera_demo
+  PRIVATE
+  include
+)
+
+target_link_libraries(camera_demo
+  cactus_rt
+)
+
+target_compile_features(camera_demo
+  PRIVATE
+  cxx_std_17
+)
+
+ament_target_dependencies(camera_demo rclcpp camera_demo_interfaces std_msgs)
+
+#############
+## Install ##
+#############
+
+install(
+  TARGETS camera_demo
+)
+
+ament_package()
+

--- a/exercise3-1/src/camera_demo/include/camera_processing_nodes.h
+++ b/exercise3-1/src/camera_demo/include/camera_processing_nodes.h
@@ -1,0 +1,36 @@
+#ifndef ROSCON_2023_REALTIME_WORKSHOP_CAMERA_PROCESSING_NODES_H_
+#define ROSCON_2023_REALTIME_WORKSHOP_CAMERA_PROCESSING_NODES_H_
+
+#include <cactus_rt/tracing.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int64.hpp>
+
+#include "camera_demo_interfaces/msg/fake_image.hpp"
+
+class RealTimeObjectDetectorNode : public rclcpp::Node {
+  std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer_;
+
+  rclcpp::Subscription<camera_demo_interfaces::msg::FakeImage>::SharedPtr subscription_;
+  rclcpp::Publisher<std_msgs::msg::Int64>::SharedPtr                      publisher_;
+
+ public:
+  explicit RealTimeObjectDetectorNode(std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer);
+
+ private:
+  void ImageCallback(const camera_demo_interfaces::msg::FakeImage::SharedPtr image);
+};
+
+class NonRealTimeDataLoggerNode : public rclcpp::Node {
+  std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer_;
+
+  rclcpp::Subscription<camera_demo_interfaces::msg::FakeImage>::SharedPtr subscription_;
+
+ public:
+  explicit NonRealTimeDataLoggerNode(std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer);
+
+ private:
+  void ImageCallback(const camera_demo_interfaces::msg::FakeImage::SharedPtr image);
+};
+
+#endif

--- a/exercise3-1/src/camera_demo/include/system_nodes.h
+++ b/exercise3-1/src/camera_demo/include/system_nodes.h
@@ -1,0 +1,36 @@
+#ifndef ROSCON_2023_REALTIME_WORKSHOP_SYSTEM_NODES_H_
+#define ROSCON_2023_REALTIME_WORKSHOP_SYSTEM_NODES_H_
+
+#include <cactus_rt/tracing.h>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int64.hpp>
+
+#include "camera_demo_interfaces/msg/fake_image.hpp"
+
+// Publishes at configurable frequency, always with real-time priority.
+class ImagePublisherNode : public rclcpp::Node {
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  rclcpp::Publisher<camera_demo_interfaces::msg::FakeImage>::SharedPtr publisher_;
+
+ public:
+  explicit ImagePublisherNode(double frequency_hz = 60.0);
+
+ private:
+  void TimerCallback();
+};
+
+class ActuationNode : public rclcpp::Node {
+  rclcpp::Subscription<std_msgs::msg::Int64>::SharedPtr subscription_;
+
+  std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer_;
+
+ public:
+  explicit ActuationNode(std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer);
+
+ private:
+  void MessageCallback(const std_msgs::msg::Int64::SharedPtr published_at_timestamp);
+};
+
+#endif

--- a/exercise3-1/src/camera_demo/include/tracing.h
+++ b/exercise3-1/src/camera_demo/include/tracing.h
@@ -1,0 +1,10 @@
+#ifndef ROSCON_2023_REALTIME_WORKSHOP_TRACING_H_
+#define ROSCON_2023_REALTIME_WORKSHOP_TRACING_H_
+
+#include <cactus_rt/tracing.h>
+
+void StartTracing(const char* app_name, const char* filename);
+void StopTracing();
+void RegisterThreadTracer(std::shared_ptr<cactus_rt::tracing::ThreadTracer> thread_tracer);
+
+#endif

--- a/exercise3-1/src/camera_demo/include/utils.h
+++ b/exercise3-1/src/camera_demo/include/utils.h
@@ -1,0 +1,14 @@
+#ifndef ROSCON_2023_REALTIME_WORKSHOP_UTILS_H_
+#define ROSCON_2023_REALTIME_WORKSHOP_UTILS_H_
+#include <cactus_rt/utils.h>
+
+#include <chrono>
+
+// A funtion to imply take up some time, pretending some processing has occured.
+inline void WasteTime(std::chrono::microseconds duration) {
+  const auto start = cactus_rt::NowNs();
+  auto       duration_ns = duration.count() * 1000;
+  while (cactus_rt::NowNs() - start < duration_ns) {
+  }
+}
+#endif

--- a/exercise3-1/src/camera_demo/package.xml
+++ b/exercise3-1/src/camera_demo/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>camera_demo_3_1</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="shuhao@shuhaowu.com">user</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>camera_demo_interfaces</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/exercise3-1/src/camera_demo/package.xml
+++ b/exercise3-1/src/camera_demo/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>camera_demo_3_1</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>ROSCon workshop excercise 3_1</description>
   <maintainer email="shuhao@shuhaowu.com">user</maintainer>
   <license>TODO: License declaration</license>
 

--- a/exercise3-1/src/camera_demo/src/camera_processing_nodes.cc
+++ b/exercise3-1/src/camera_demo/src/camera_processing_nodes.cc
@@ -1,0 +1,57 @@
+#include "camera_processing_nodes.h"
+
+#include "utils.h"
+
+using cactus_rt::tracing::ThreadTracer;
+using camera_demo_interfaces::msg::FakeImage;
+
+RealTimeObjectDetectorNode::RealTimeObjectDetectorNode(
+  std::shared_ptr<ThreadTracer> tracer
+) : Node("obj_detect"), tracer_(tracer) {
+  subscription_ = this->create_subscription<FakeImage>(
+    "/image",
+    10,
+    std::bind(&RealTimeObjectDetectorNode::ImageCallback, this, std::placeholders::_1)
+  );
+
+  publisher_ = this->create_publisher<std_msgs::msg::Int64>("/actuation", 10);
+}
+
+void RealTimeObjectDetectorNode::ImageCallback(const FakeImage::SharedPtr image) {
+  // A hack to trace the message passing delay between publisher and this node
+  auto now = cactus_rt::NowNs();
+  tracer_->StartSpan("MessageDelay", nullptr, image->published_at_monotonic_nanos);
+  tracer_->EndSpan(now);
+
+  {
+    auto span = tracer_->WithSpan("ObjectDetect");
+
+    // Pretend it takes 4000 ms to do object detection.
+    WasteTime(std::chrono::microseconds(4000));
+
+    // Send a signal to the downstream actuation node
+    std_msgs::msg::Int64 msg;
+    msg.data = image->published_at_monotonic_nanos;
+    publisher_->publish(msg);
+  }
+}
+
+NonRealTimeDataLoggerNode::NonRealTimeDataLoggerNode(
+  std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer
+) : Node("data_logger"), tracer_(tracer) {
+  subscription_ = this->create_subscription<FakeImage>(
+    "/image",
+    10,
+    std::bind(&NonRealTimeDataLoggerNode::ImageCallback, this, std::placeholders::_1)
+  );
+}
+
+void NonRealTimeDataLoggerNode::ImageCallback(const FakeImage::SharedPtr image) {
+  auto span = tracer_->WithSpan("DataLogger");
+
+  // Assume it takes 1ms to serialize the data which is all on the CPU
+  WasteTime(std::chrono::microseconds(1000));
+
+  // Assume it takes about 1ms to write the data where it is blocking but yielded to the CPU.
+  std::this_thread::sleep_for(std::chrono::microseconds(1000));
+}

--- a/exercise3-1/src/camera_demo/src/main.cc
+++ b/exercise3-1/src/camera_demo/src/main.cc
@@ -1,0 +1,38 @@
+#include <rclcpp/rclcpp.hpp>
+
+#include "camera_processing_nodes.h"
+#include "system_nodes.h"
+#include "tracing.h"
+
+int main(int argc, char** argv) {
+  rclcpp::init(argc, argv);
+
+  auto image_publisher_node = std::make_shared<ImagePublisherNode>(60.0);
+
+  auto actuation_tracer = std::make_shared<cactus_rt::tracing::ThreadTracer>("actuation");
+  auto actuation_node = std::make_shared<ActuationNode>(actuation_tracer);
+
+  auto object_detector_tracer = std::make_shared<cactus_rt::tracing::ThreadTracer>("obj_detect");
+  auto object_detector_node = std::make_shared<RealTimeObjectDetectorNode>(object_detector_tracer);
+
+  auto data_logger_tracer = std::make_shared<cactus_rt::tracing::ThreadTracer>("data_logger");
+  auto data_logger_node = std::make_shared<NonRealTimeDataLoggerNode>(data_logger_tracer);
+
+  StartTracing("camera_demo_3_1", "exercise3-1.perfetto");
+  RegisterThreadTracer(actuation_tracer);
+  RegisterThreadTracer(object_detector_tracer);
+  RegisterThreadTracer(data_logger_tracer);
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+
+  executor.add_node(image_publisher_node);
+  executor.add_node(object_detector_node);
+  executor.add_node(data_logger_node);
+  executor.add_node(actuation_node);
+  executor.spin();
+
+  rclcpp::shutdown();
+
+  StopTracing();
+  return 0;
+}

--- a/exercise3-1/src/camera_demo/src/system_nodes.cc
+++ b/exercise3-1/src/camera_demo/src/system_nodes.cc
@@ -1,0 +1,50 @@
+#include "system_nodes.h"
+
+#include <cactus_rt/utils.h>
+
+#include "utils.h"
+
+using camera_demo_interfaces::msg::FakeImage;
+
+ImagePublisherNode::ImagePublisherNode(
+  double frequency_hz
+) : Node("imagepub") {
+  timer_ = this->create_wall_timer(
+    std::chrono::microseconds(static_cast<int>(1000000 / frequency_hz)),
+    std::bind(&ImagePublisherNode::TimerCallback, this)
+  );
+
+  publisher_ = this->create_publisher<FakeImage>("/image", 10);
+}
+
+void ImagePublisherNode::TimerCallback() {
+  FakeImage img;
+  img.data = {127};
+  img.published_at_monotonic_nanos = cactus_rt::NowNs();
+
+  publisher_->publish(img);
+}
+
+ActuationNode::ActuationNode(
+  std::shared_ptr<cactus_rt::tracing::ThreadTracer> tracer
+) : Node("actuation"), tracer_(tracer) {
+  subscription_ = this->create_subscription<std_msgs::msg::Int64>(
+    "/actuation",
+    10,
+    std::bind(&ActuationNode::MessageCallback, this, std::placeholders::_1)
+  );
+}
+
+void ActuationNode::MessageCallback(const std_msgs::msg::Int64::SharedPtr published_at_timestamp) {
+  auto now = cactus_rt::NowNs();
+
+  // A hack to show the end to end latency, from the moment it was published to
+  // the moment it is received by this node.
+  tracer_->StartSpan("MessageProcessing", nullptr, published_at_timestamp->data);
+  tracer_->EndSpan(now);
+
+  {
+    auto span = tracer_->WithSpan("Actuation");
+    WasteTime(std::chrono::microseconds(150));
+  }
+}

--- a/exercise3-1/src/camera_demo/src/tracing.cc
+++ b/exercise3-1/src/camera_demo/src/tracing.cc
@@ -1,0 +1,34 @@
+#include "tracing.h"
+
+using cactus_rt::tracing::FileSink;
+using cactus_rt::tracing::ThreadTracer;
+using cactus_rt::tracing::TraceAggregator;
+
+std::unique_ptr<TraceAggregator> trace_aggregator;
+
+void StartTracing(const char* app_name, const char* filename) {
+  // Enable the tracing.
+  cactus_rt::tracing::EnableTracing();
+
+  // Create the trace aggregator that will pop the queues and write the events to sinks.
+  trace_aggregator = std::make_unique<TraceAggregator>(app_name);
+
+  // Create the file sink so the data aggregated by the TraceAggregator will be written to somewhere.
+  auto file_sink = std::make_shared<FileSink>(filename);
+  trace_aggregator->RegisterSink(file_sink);
+
+  quill::start();
+  trace_aggregator->Start();
+}
+
+void StopTracing() {
+  cactus_rt::tracing::DisableTracing();
+
+  trace_aggregator->RequestStop();
+  trace_aggregator->Join();
+  trace_aggregator = nullptr;  // Destroy the trace aggregator and free all resources.
+}
+
+void RegisterThreadTracer(std::shared_ptr<ThreadTracer> thread_tracer) {
+  trace_aggregator->RegisterThreadTracer(thread_tracer);
+}

--- a/exercise3-1/src/camera_demo_interfaces/CMakeLists.txt
+++ b/exercise3-1/src/camera_demo_interfaces/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.18)
+project(camera_demo_interfaces)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/FakeImage.msg"
+)
+
+ament_package()

--- a/exercise3-1/src/camera_demo_interfaces/msg/FakeImage.msg
+++ b/exercise3-1/src/camera_demo_interfaces/msg/FakeImage.msg
@@ -1,0 +1,6 @@
+# This is the timestamp in CLOCK_MONOTONIC in nanoseconds right before this message is published.
+int64 published_at_monotonic_nanos
+
+# This is the fake image data. It's a bit small and approximates 640 x 480
+# pixels of 8-bit black and white images.
+int8[307200] data

--- a/exercise3-1/src/camera_demo_interfaces/package.xml
+++ b/exercise3-1/src/camera_demo_interfaces/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>camera_demo_interfaces</name>
+  <version>0.0.0</version>
+  <description>Interfaces for the camera demo example</description>
+  <maintainer email="shuhao@shuhaowu.com">Shuhao</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+


### PR DESCRIPTION
@JanStaschulat @nightduck  Please review and try this ASAP

Run instructions:

1. Clone/update the repository. Checkout this branch (`git checkout exercise3-1`). Make sure to run `git submodule init && git submodule update` after you `git pull`.
2. `cd exercise3-1`
3. `colcon build`
4. `install/camera_demo_3_1/bin/camera_demo`
5. Let this run for a few seconds.
6. Press CTRL+C to terminate it after a few seconds.
7. Go to https://cactusdynamics.github.io/perfetto
8. Open the `exercise3-1.perfetto` file that is created in the `exercise3-1` folder and see the following (use `W` to zoom in, `A` to zoom out, `S` and `D` to move left and right in the viewer):

![image](https://github.com/ros-realtime/roscon-2023-realtime-workshop/assets/338100/848d6fdc-7d57-4d53-bc54-e67323d2b71b)

The `MessageProcessing` is the total time between the message publish by the publisher node and when it is received by the actuation node. The `MessageDelay` (red box) is the time between the message publish by the publisher node and when it is received by the object detector node. The `ObjectDetect` and `DataLogger` are the callbacks for those two nodes respectively. The `Actuation` (orange box at the end) is the time taken for the actuation callback.

You can add `stress-ng -c $(nproc)` for stressing your system and run this at the same time. I haven't tried this yet and the results should be bad, because all nodes are currently running with the `SingleThreadedExecutor`. We should consider making the image publisher node permanently real time so it will keep a consistent image rate as we discussed, and that any deadline miss should occur on the other nodes, as we discussed.

We can extend this code with the experimental executor and also extend this code with the callback group for exercise 4.